### PR TITLE
Update version, add retry policy, and include GreenPipes

### DIFF
--- a/Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj
+++ b/Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>1.1.0</Version>
+	  <Version>1.1.1</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Play.Economy.Common</Product>

--- a/Berrevoets.Play.Economy.Common/MassTransit/Extensions.cs
+++ b/Berrevoets.Play.Economy.Common/MassTransit/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using GreenPipes;
 using MassTransit;
 using MassTransit.Definition;
 using Microsoft.Extensions.Configuration;
@@ -14,11 +15,12 @@ public static class Extensions
         builder.Services.AddMassTransit(configure =>
         {
             configure.AddConsumers(Assembly.GetEntryAssembly());
-            
+
             configure.UsingRabbitMq((context, cfg) =>
             {
                 cfg.Host(builder.Configuration.GetConnectionString("rabbitmq"));
                 cfg.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter(prefix, false));
+                cfg.UseMessageRetry(retryConfigurator => { retryConfigurator.Interval(3, TimeSpan.FromSeconds(5)); });
             });
         });
 


### PR DESCRIPTION
Updated the target framework in the Berrevoets.Play.Economy.Common.csproj file from net8.0 to net8.0. Incremented the version number from 1.1.0 to 1.1.1. Added the GreenPipes namespace to the Extensions.cs file. Implemented a message retry policy in the Extensions class for RabbitMQ configuration, allowing up to 3 retries with a 5-second interval.