### PR TITLE
Update to .NET 9.0, bump versions, and remove MassTransit

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -38,7 +38,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x' # Adjust according to your project's target framework
+        dotnet-version: '9.0.x' # Adjust according to your project's target framework
 
     - name: Restore dependencies
       run: dotnet restore
@@ -39,7 +39,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x' # Adjust according to your project's target framework
+        dotnet-version: '9.0.x' # Adjust according to your project's target framework
 
     - name: Restore dependencies
       run: dotnet restore

--- a/Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj
+++ b/Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>1.1.1</Version>
+	  <Version>1.1.2</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Play.Economy.Common</Product>
@@ -39,13 +39,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.MongoDB.Driver" Version="8.2.2" />
-		<PackageReference Include="MassTransit.AspNetCore" Version="7.3.1" />
-		<PackageReference Include="MassTransit.RabbitMQ" Version="7.3.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+		<PackageReference Include="Aspire.MongoDB.Driver" Version="9.0.0" />
+		<PackageReference Include="MassTransit.RabbitMQ" Version="8.3.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Berrevoets.Play.Economy.Common/MassTransit/Extensions.cs
+++ b/Berrevoets.Play.Economy.Common/MassTransit/Extensions.cs
@@ -1,7 +1,5 @@
 ﻿using System.Reflection;
-using GreenPipes;
 using MassTransit;
-using MassTransit.Definition;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -23,8 +21,6 @@ public static class Extensions
                 cfg.UseMessageRetry(retryConfigurator => { retryConfigurator.Interval(3, TimeSpan.FromSeconds(5)); });
             });
         });
-
-        builder.Services.AddMassTransitHostedService();
 
         return builder;
     }


### PR DESCRIPTION
Updated target framework from .NET 8.0 to .NET 9.0. Incremented project version from 1.1.1 to 1.1.2.
Updated several package references to newer versions:
  - Aspire.MongoDB.Driver: 8.2.2 -> 9.0.0
  - MassTransit.RabbitMQ: 7.3.1 -> 8.3.1
  - Microsoft.Extensions.Configuration: 8.0.0 -> 9.0.0
  - Microsoft.Extensions.Configuration.Binder: 8.0.2 -> 9.0.0
  - Microsoft.Extensions.DependencyInjection: 8.0.1 -> 9.0.0
  - Microsoft.Extensions.Hosting: 8.0.1 -> 9.0.0 Removed MassTransit.AspNetCore package reference.
Removed GreenPipes and MassTransit.Definition namespaces from Extensions.cs. Removed call to builder.Services.AddMassTransitHostedService() from Extensions class.