### PR TITLE
Add workflows for preview and final NuGet package publishing

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - Development
   workflow_dispatch:
+  push:
+    branches:
+      - Development
 
 jobs:
   build:
@@ -29,7 +32,20 @@ jobs:
     - name: Run tests
       run: dotnet test --no-restore --verbosity normal
 
+    - name: Extract version from .csproj and append -preview
+      id: extract-version
+      run: |
+        VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj)
+        if [ -z "$VERSION" ]; then
+          echo "Error: Version could not be extracted."
+          exit 1
+        fi
+        VERSION="$VERSION-preview"
+        echo "::set-output name=version::$VERSION"
+        echo "Version extracted: $VERSION"
+
   publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/Development') }}
     needs: build
     runs-on: windows-latest
     steps:
@@ -44,35 +60,29 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Extract version from .csproj and append -preview
-      id: extract-version
-      shell: bash
+    - name: Clean output directory
       run: |
-        VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj)
-        if [ -z "$VERSION" ]; then
-          echo "Error: Version could not be extracted."
-          exit 1
+        if [ -d "${{ github.workspace }}/output" ]; then
+          rm -rf "${{ github.workspace }}/output"
         fi
-        VERSION="$VERSION-preview"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "Version extracted: $VERSION"
+        mkdir "${{ github.workspace }}/output"
 
     - name: Build the solution (Release) again for packaging
       run: |
-        echo "Building NuGet package with version: ${{ env.VERSION }}"
-        dotnet build Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release /p:PackageVersion=${{ env.VERSION }}
+        echo "Building NuGet package with version: ${{ needs.build.outputs.version }}"
+        dotnet build Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release /p:PackageVersion=${{ needs.build.outputs.version }}
 
     - name: Pack Preview NuGet package (with symbols)
       run: |
-        echo "Packing NuGet package with version: ${{ env.VERSION }}"
-        dotnet pack Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release --output "${{ github.workspace }}\output" /p:PackageVersion=${{ env.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
+        echo "Packing NuGet package with version: ${{ needs.build.outputs.version }}"
+        dotnet pack Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ needs.build.outputs.version }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: Publish Preview NuGet package
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}/output/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Publish Symbol Package (.snupkg)
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      run: dotnet nuget push "${{ github.workspace }}\output\*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "${{ github.workspace }}/output/*.snupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -17,7 +20,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x' # Adjust according to your project's target framework
+        dotnet-version: '9.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -29,7 +32,7 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
 
   publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: build
     runs-on: windows-latest
 
@@ -40,13 +43,17 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x' # Adjust according to your project's target framework
+        dotnet-version: '9.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Build the solution
-      run: dotnet build --configuration Release --no-restore
+    - name: Clean output directory
+      run: |
+        if [ -d "${{ github.workspace }}/output" ]; then
+          rm -rf "${{ github.workspace }}/output"
+        fi
+        mkdir "${{ github.workspace }}/output"
 
     - name: Pack Final NuGet package (with symbols)
       run: dotnet pack Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release --output "${{ github.workspace }}\output" /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg


### PR DESCRIPTION
Introduce new workflows in `CI-development.yml` and `CI.yml` for building and publishing preview and final NuGet packages. The `CI-development.yml` workflow triggers on pull requests and pushes to the `Development` branch, and manually via `workflow_dispatch`. It includes steps to extract the version from the `.csproj` file, append `-preview`, and use it in subsequent steps. The `publish` job runs on `workflow_dispatch` events or pushes to the `Development` branch, cleaning the output directory, building, packing, and publishing the NuGet and symbol packages.

Similar updates are made to `CI.yml` for the `main` branch, ensuring correct versioning and packaging steps for final NuGet packages. The `publish` job in `CI.yml` also cleans the output directory before packing and publishing the final NuGet and symbol packages.