### PR TITLE
Add step to clean output directory in CI pipelines

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -62,6 +62,7 @@ jobs:
       run: dotnet restore
 
     - name: Clean output directory
+      shell: bash
       run: |
         if [ -d "${{ github.workspace }}/output" ]; then
           rm -rf "${{ github.workspace }}/output"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,7 @@ jobs:
       run: dotnet restore
 
     - name: Clean output directory
+      shell: bash
       run: |
         if [ -d "${{ github.workspace }}/output" ]; then
           rm -rf "${{ github.workspace }}/output"


### PR DESCRIPTION
Added a new step in CI-development.yml and CI.yml to clean the output directory. This step uses a bash script to check for the existence of the output directory, remove it if it exists, and create a new one. This ensures a clean state for the output directory before proceeding with the next steps in the CI pipeline.