### PR TITLE
Remove IncludeSource and ls steps from CI configs

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Pack Preview NuGet package (with symbols)
       run: |
         echo "Packing NuGet package with version: ${{ needs.build.outputs.version }}"
-        dotnet pack Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ needs.build.outputs.version }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:IncludeSource=true
+        dotnet pack Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ needs.build.outputs.version }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: List output directory
       shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Pack Final NuGet package (with symbols)
       run: |
         echo "Packing NuGet package with version: ${{ needs.build.outputs.version }}"
-        dotnet pack Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ needs.build.outputs.version }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:IncludeSource=true
+        dotnet pack Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj --configuration Release --output "${{ github.workspace }}/output" /p:PackageVersion=${{ needs.build.outputs.version }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 
     - name: List output directory
       shell: bash


### PR DESCRIPTION
The changes in the CI-development.yml and CI.yml files involve modifications to the steps for packing the NuGet package. Specifically, the `/p:IncludeSource=true` parameter has been removed from the `dotnet pack` command. This parameter was previously used to include the source code in the NuGet package. Additionally, the step to list the output directory using the `ls` command has been removed from both files.

This will be hopefully the final scripts :)