### PR TITLE
Add ServiceName property to ServiceSettings class

### DIFF
--- a/Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj
+++ b/Berrevoets.Play.Economy.Common/Berrevoets.Play.Economy.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>1.1.2</Version>
+	  <Version>1.1.3</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Play.Economy.Common</Product>

--- a/Berrevoets.Play.Economy.Common/Settings/ServiceSettings.cs
+++ b/Berrevoets.Play.Economy.Common/Settings/ServiceSettings.cs
@@ -2,6 +2,7 @@
 
 public class ServiceSettings
 {
+    public string ServiceName   { get; init; } = string.Empty;
     public string DatabaseName   { get; init; } = string.Empty;
     public string CollectionName { get; init; } = string.Empty;
 }


### PR DESCRIPTION
Introduced a new `ServiceName` property to the `ServiceSettings` class. This string property is initialized to an empty string and uses the `init` accessor, allowing it to be set only during object initialization. This change is intended to store the name of the service in the settings configuration.